### PR TITLE
Fix comment hyphen characters

### DIFF
--- a/generate_secret.sh
+++ b/generate_secret.sh
@@ -2,13 +2,13 @@
 #
 # generate_secret.sh
 # 
-# Generates a 24‐byte random Flask SECRET_KEY (hex‐encoded),
+# Generates a 24-byte random Flask SECRET_KEY (hex-encoded),
 # writes it to .env (overwriting any existing FLASK_SECRET_KEY),
 # and preserves any other lines in .env (like OPENAI_API_KEY).
 
 ENV_FILE=".env"
 
-# 1. Generate a new 24‐byte hex string
+# 1. Generate a new 24-byte hex string
 NEW_KEY=$(python3 - <<EOF
 import os
 print(os.urandom(24).hex())


### PR DESCRIPTION
## Summary
- normalize hyphen characters in `generate_secret.sh`

## Testing
- `python3 -m py_compile app/__init__.py app/routes.py app/services/__init__.py app/services/openai_service.py app/utils/__init__.py app/utils/exif_utils.py run.py`


------
https://chatgpt.com/codex/tasks/task_e_68439ede1fb48320bd3c27a0523ff245