### PR TITLE
Fix PostCSS config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: [
+    require('tailwindcss'),
+    require('autoprefixer'),
+  ]
+};


### PR DESCRIPTION
## Summary
- add missing PostCSS configuration to enable Tailwind and autoprefixer

## Testing
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_6843a1419fec8320b05c1b3282bf4c51